### PR TITLE
Fix azure key error in FilePipeline

### DIFF
--- a/scrapy_azure_exporter/azure_pipelines.py
+++ b/scrapy_azure_exporter/azure_pipelines.py
@@ -6,13 +6,15 @@ from scrapy.pipelines.images import ImagesPipeline
 class AzurePipelineMixin:
     @classmethod
     def from_settings(cls, settings):
-        pipeline = super().from_settings(settings)
-        pipeline.STORE_SCHEMES.update(
+        // upstream from_settings need the 'azure' key to be available
+        cls.STORE_SCHEMES.update(
             {
                 "azure": AzureFilesStore.new(settings),
                 "azurite": AzureFilesStore.new(settings),
             }
         )
+        
+        pipeline = super().from_settings(settings)
         return pipeline
 
 


### PR DESCRIPTION
Bug with most recent version of scrapy (v2.11) where base class expects 'azure' key to be set, but not available as instantiation in the mixin is in the wrong order causing a key error on line 398 _get_store in scrapy.pipelines.files.py

